### PR TITLE
feat: Zweiter Lineup-Tag für Festival 2026

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -18,16 +18,16 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           show-progress: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: "npm"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.npm
@@ -63,14 +63,14 @@ jobs:
           NEXT_PUBLIC_GITHUB_REF: ${{ github.ref }}
           NEXT_PUBLIC_GITHUB_RUN_ID: ${{ github.run_id }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: build/
 
       - name: Report issue to Discord
         if: failure()
-        uses: Ilshidur/action-discord@0.3.2
+        uses: Ilshidur/action-discord@0.4.0
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_INTEGRATION_REPORTER_WEBHOOK_URL }}
           DISCORD_USERNAME: "GitHub Actions"
@@ -86,17 +86,17 @@ jobs:
     environment: Staging
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           show-progress: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: build-output
           path: build
 
       - name: Deploy Website
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USER }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Report issue to Discord
         if: failure() && github.ref == 'refs/heads/main'
-        uses: Ilshidur/action-discord@0.3.2
+        uses: Ilshidur/action-discord@0.4.0
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_INTEGRATION_REPORTER_WEBHOOK_URL }}
           DISCORD_USERNAME: "GitHub Actions"
@@ -129,17 +129,17 @@ jobs:
     environment: Production
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           show-progress: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: build-output
           path: build
 
       - name: Deploy Website
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USER }}
@@ -155,60 +155,13 @@ jobs:
 
       - name: Report issue to Discord
         if: failure() && github.ref == 'refs/heads/main'
-        uses: Ilshidur/action-discord@0.3.2
+        uses: Ilshidur/action-discord@0.4.0
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_INTEGRATION_REPORTER_WEBHOOK_URL }}
           DISCORD_USERNAME: "GitHub Actions"
           DISCORD_EMBEDS: "{}"
         with:
           args: "Website deployment to **production** failed :rotating_light:"
-
-  #   deploy-styleguide:
-  #     name: Deploy - Styleguide
-  #     needs: [build]
-  #     environment: Styleguide
-  #     runs-on: ubuntu-latest
-
-  #     steps:
-  #       - uses: actions/checkout@v4
-
-  #       - uses: dorny/paths-filter@v2
-  #         id: changes
-  #         with:
-  #           filters: |
-  #             src:
-  #               - 'tailwind.config.js'
-  #               - 'postcss.config.js'
-  #               - 'package.json'
-
-  #       - uses: actions/setup-node@v3
-  #         if: steps.changes.outputs.src == 'true'
-  #         with:
-  #           node-version-file: .nvmrc
-  #           cache: "npm"
-
-  #       - run: npm install
-  #         if: steps.changes.outputs.src == 'true'
-
-  #       - run: npm run tailwind:export
-  #         if: steps.changes.outputs.src == 'true'
-
-  #       - name: Deploy Styleguide
-  #         if: steps.changes.outputs.src == 'true'
-  #         uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-  #         continue-on-error: true
-  #         with:
-  #           server: ${{ secrets.FTP_SERVER }}
-  #           username: ${{ secrets.FTP_USER }}
-  #           password: ${{ secrets.FTP_PASSWORD }}
-  #           local-dir: ./styleguide/
-  #           server-dir: ${{ vars.SERVER_DIR }}
-  #           exclude: |
-  #             **/.DS_Store
-  #             **/.vscode
-  #             **/.git*
-  #             **/.git*/**
-  #             **/.github/**
 
   notify:
     name: Notify

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,17 +24,17 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v7
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v2
+              uses: github/codeql-action/init@v4
               with:
                   languages: ${{ matrix.language }}
 
             # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v2
+              uses: github/codeql-action/autobuild@v4
 
             # ℹ️ Command-line programs to run using the OS shell.
             # 📚 https://git.io/JvXDl
@@ -48,4 +48,4 @@ jobs:
             #   make release
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v2
+              uses: github/codeql-action/analyze@v4

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -24,15 +24,15 @@ jobs:
     analyze:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v7
 
             - name: Install Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v7
               with:
                   node-version: 18
 
             - name: Install dependencies
-              uses: bahmutov/npm-install@v1
+              run: npm install
 
             # If pnpm is used, you need to switch the previous step with the following one. pnpm does not create a package-lock.json
             # so the step above will fail to pull dependencies
@@ -44,7 +44,7 @@ jobs:
             #     run_install: true
 
             - name: Restore next build
-              uses: actions/cache@v3
+              uses: actions/cache@v6
               id: restore-build-cache
               env:
                   cache-name: cache-next-build
@@ -86,13 +86,13 @@ jobs:
               run: npx -p nextjs-bundle-analysis report
 
             - name: Upload bundle
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v7
               with:
                   name: bundle
                   path: .next/analyze/__bundle_analysis.json
 
             - name: Download base branch bundle stats
-              uses: dawidd6/action-download-artifact@v2
+              uses: dawidd6/action-download-artifact@v21
               if: success() && github.event.number
               with:
                   workflow: nextjs_bundle_analysis.yml
@@ -126,7 +126,7 @@ jobs:
                   echo EOF >> $GITHUB_OUTPUT
 
             - name: Find Comment
-              uses: peter-evans/find-comment@v2
+              uses: peter-evans/find-comment@v4
               if: success() && github.event.number
               id: fc
               with:
@@ -134,14 +134,14 @@ jobs:
                   body-includes: '<!-- __NEXTJS_BUNDLE -->'
 
             - name: Create Comment
-              uses: peter-evans/create-or-update-comment@v2
+              uses: peter-evans/create-or-update-comment@v5
               if: success() && github.event.number && steps.fc.outputs.comment-id == 0
               with:
                   issue-number: ${{ github.event.number }}
                   body: ${{ steps.get-comment-body.outputs.body }}
 
             - name: Update Comment
-              uses: peter-evans/create-or-update-comment@v2
+              uses: peter-evans/create-or-update-comment@v5
               if: success() && github.event.number && steps.fc.outputs.comment-id != 0
               with:
                   issue-number: ${{ github.event.number }}

--- a/graphql/queries/pages/Festival.graphql
+++ b/graphql/queries/pages/Festival.graphql
@@ -48,6 +48,14 @@ query FestivalDetailQuery($filter: JsonType, $sort: JsonType) {
 				value
 			}
 		}
+		timetableDay2 {
+			title
+			description
+			slug_slug
+			slots {
+				value
+			}
+		}
 		sponsors {
 			title
 			type

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -315,6 +315,7 @@ type Festival implements CockpitField {
 	text: String!
 	date: String!
 	timetable: Timetable
+	timetableDay2: Timetable
 	endDate: String
 	location: Location
 	ticketingUrl: String

--- a/pages/festival/[year].tsx
+++ b/pages/festival/[year].tsx
@@ -107,9 +107,9 @@ export const getStaticPaths: GetStaticPaths = async () => {
 };
 
 const LineupList: FC<{ entries: LineupEntry[] }> = ({ entries }) => (
-	<ol data-nosnippet className="flex flex-col flex-wrap gap-6">
+	<ol data-nosnippet className="flex flex-col flex-wrap gap-3">
 		{entries.map((entry) => (
-			<li key={entry.playtime} className="flex flex-row gap-4 align-center items-center">
+			<li key={entry.playtime} className="flex flex-row gap-2 align-center items-center">
 				<p className="grow-0 w-[80px] md:w-[120px]">{entry.playtime}</p>
 				<Heading level="4" className="text-lg flex-grow">
 					{entry.artist}{' '}
@@ -226,29 +226,26 @@ const FestivalYearPage: NextPage<Awaited<ReturnType<typeof getStaticProps>>['pro
 							{/* Timetable */}
 							{(lineup.length > 0 || lineupDay2.length > 0) && (
 								<div className="mb-10" data-nosnippet>
-									<Heading level="2">Lineup</Heading>
-									{lineupDay2.length > 0 ? (
+									<Heading level="2" className="mb-8">
+										Timetable
+									</Heading>
+									{lineup.length > 0 && lineupDay2.length > 0 ? (
 										<>
-											{lineup.length > 0 && (
-												<section className="mb-10">
-													<Heading level="3" className="mb-6">
-														{festival.timetable?.title || 'Tag 1'}
-													</Heading>
-													<LineupList entries={lineup} />
-												</section>
-											)}
+											<section className="mb-10">
+												<Heading level="3" visualLevel="4" className="mb-6">
+													Freitag
+												</Heading>
+												<LineupList entries={lineup} />
+											</section>
 											<section>
-												<Heading level="3" className="mb-6">
-													{festival.timetableDay2?.title || 'Tag 2'}
+												<Heading level="3" visualLevel="4" className="mb-6">
+													Samstag
 												</Heading>
 												<LineupList entries={lineupDay2} />
 											</section>
 										</>
 									) : (
-										<>
-											<p className="mb-6">Running Order</p>
-											<LineupList entries={lineup} />
-										</>
+										<LineupList entries={lineup} />
 									)}
 								</div>
 							)}

--- a/pages/festival/[year].tsx
+++ b/pages/festival/[year].tsx
@@ -1,3 +1,4 @@
+import type { FC } from 'react';
 import type { NextPage, GetStaticPaths, GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import { PartnerType } from '../../graphql';
@@ -28,19 +29,26 @@ import { TicketIcon, UserGroupIcon } from '@heroicons/react/24/outline';
 import { JsonLd } from '../../components/utils/JsonLd';
 import { useTranslation } from '../../hooks/useTranslation';
 
+interface LineupEntry {
+	artist: string;
+	labels: string;
+	playtime: string;
+}
+
+type FestivalDetail = Awaited<ReturnType<typeof getFestivalByYear>>;
+
+const getLineup = (timetable: FestivalDetail['timetable']): LineupEntry[] =>
+	(timetable?.slots?.map((slot) => slot?.value) as LineupEntry[]) || [];
+
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
 	const year = params && params.year ? `${params.year}` : undefined;
 
 	// data aggregation
 	const allFestivalYears = await getFestivalYears();
 	const festival = await getFestivalByYear(year!);
-	const lineup =
-		(festival.timetable?.slots?.map((slot) => slot?.value) as Array<{
-			artist: string;
-			labels: string;
-			playtime: string;
-		}>) || [];
-	const artistsSeoString = lineup
+	const lineup = getLineup(festival.timetable);
+	const lineupDay2 = getLineup(festival.timetableDay2);
+	const artistsSeoString = [...lineup, ...lineupDay2]
 		.map((entry) => `${entry.artist} ${entry.labels ? `(${entry.labels})` : ''}`)
 		.join(', ');
 
@@ -74,6 +82,7 @@ export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
 		props: {
 			year,
 			lineup,
+			lineupDay2,
 			sponsors,
 			// events,
 			// pastEvents,
@@ -97,11 +106,28 @@ export const getStaticPaths: GetStaticPaths = async () => {
 	};
 };
 
+const LineupList: FC<{ entries: LineupEntry[] }> = ({ entries }) => (
+	<ol data-nosnippet className="flex flex-col flex-wrap gap-6">
+		{entries.map((entry) => (
+			<li key={entry.playtime} className="flex flex-row gap-4 align-center items-center">
+				<p className="grow-0 w-[80px] md:w-[120px]">{entry.playtime}</p>
+				<Heading level="4" className="text-lg flex-grow">
+					{entry.artist}{' '}
+					{entry.labels && <small className="font-normal block md:inline">({entry.labels})</small>}
+				</Heading>
+			</li>
+		))}
+	</ol>
+);
+
+LineupList.displayName = 'LineupList';
+
 const FestivalYearPage: NextPage<Awaited<ReturnType<typeof getStaticProps>>['props']> = ({
 	contentProviderProps,
 	year,
 	festival,
 	lineup,
+	lineupDay2,
 	sponsors,
 	allFestivalYears,
 }) => {
@@ -198,28 +224,32 @@ const FestivalYearPage: NextPage<Awaited<ReturnType<typeof getStaticProps>>['pro
 							)}
 
 							{/* Timetable */}
-							{lineup && lineup.length > 0 && (
+							{(lineup.length > 0 || lineupDay2.length > 0) && (
 								<div className="mb-10" data-nosnippet>
 									<Heading level="2">Lineup</Heading>
-									<p className="mb-6">Running Order</p>
-									<ol data-nosnippet className="flex flex-col flex-wrap gap-6">
-										{lineup.map((entry) => (
-											<li
-												key={entry.playtime}
-												className="flex flex-row gap-4 align-center items-center"
-											>
-												<p className="grow-0 w-[80px] md:w-[120px]">{entry.playtime}</p>
-												<Heading level="4" className="text-lg flex-grow">
-													{entry.artist}{' '}
-													{entry.labels && (
-														<small className="font-normal block md:inline">
-															({entry.labels})
-														</small>
-													)}
+									{lineupDay2.length > 0 ? (
+										<>
+											{lineup.length > 0 && (
+												<section className="mb-10">
+													<Heading level="3" className="mb-6">
+														Tag 1 – {formatDate(festival.date)}
+													</Heading>
+													<LineupList entries={lineup} />
+												</section>
+											)}
+											<section>
+												<Heading level="3" className="mb-6">
+													Tag 2{festival.endDate && ` – ${formatDate(festival.endDate)}`}
 												</Heading>
-											</li>
-										))}
-									</ol>
+												<LineupList entries={lineupDay2} />
+											</section>
+										</>
+									) : (
+										<>
+											<p className="mb-6">Running Order</p>
+											<LineupList entries={lineup} />
+										</>
+									)}
 								</div>
 							)}
 

--- a/pages/festival/[year].tsx
+++ b/pages/festival/[year].tsx
@@ -232,14 +232,14 @@ const FestivalYearPage: NextPage<Awaited<ReturnType<typeof getStaticProps>>['pro
 											{lineup.length > 0 && (
 												<section className="mb-10">
 													<Heading level="3" className="mb-6">
-														Tag 1 – {formatDate(festival.date)}
+														{festival.timetable?.title || 'Tag 1'}
 													</Heading>
 													<LineupList entries={lineup} />
 												</section>
 											)}
 											<section>
 												<Heading level="3" className="mb-6">
-													Tag 2{festival.endDate && ` – ${formatDate(festival.endDate)}`}
+													{festival.timetableDay2?.title || 'Tag 2'}
 												</Heading>
 												<LineupList entries={lineupDay2} />
 											</section>


### PR DESCRIPTION
## Was wurde gemacht?
Das Rheinklang Festival 2026 findet neu an zwei Tagen statt 
(14. & 15. August). Bisher konnte im CMS nur ein Lineup 
verknüpft werden.

## Änderungen
- CMS: Neues Feld `timetableDay2` auf der Festivals-Collection angelegt
- `graphql/schema.graphql`: `timetableDay2: Timetable` ergänzt
- `graphql/queries/pages/Festival.graphql`: Query um `timetableDay2` erweitert
- `pages/festival/[year].tsx`: Lineup wird neu getrennt nach Tag 1 / Tag 2 gerendert, Überschriften kommen direkt aus den CMS-Timetable-Titeln

## Geprüft
- Lokal auf Dev-Server getestet
- Typecheck grün
- Alte Festival-Jahre (2025, 2024) zeigen keine Regression